### PR TITLE
Dev v2 21

### DIFF
--- a/expect/dhcp.exp
+++ b/expect/dhcp.exp
@@ -180,7 +180,7 @@ dialog "Enable RMCP access (y/n) (RET=\*): " ""
 dialog "Enable telnet access (y/n) (RET=\*): " ""
 dialog "Enable WEB access (y/n) (RET=\*): " ""
 dialog "Enable ssh access (y/n) (RET=\*): " ""
-if { $FWVER == "2.21.2" } {
+if { $FWVER == "2.21" } {
     dialog "Enable xvc access (y/n) (RET=\*): " ""
 }
 dialog "Enter IP address source Mgmt (dec) (RET=\*): " "2"

--- a/expect/dhcp.exp
+++ b/expect/dhcp.exp
@@ -59,6 +59,11 @@ set port [lindex $argv 1]
 #
 set DATE [lindex $argv 2]
 #
+# FW version
+#
+set FWVER [lindex $argv 3]
+
+#
 # MCH Configuration Commands File
 #
 
@@ -175,6 +180,9 @@ dialog "Enable RMCP access (y/n) (RET=\*): " ""
 dialog "Enable telnet access (y/n) (RET=\*): " ""
 dialog "Enable WEB access (y/n) (RET=\*): " ""
 dialog "Enable ssh access (y/n) (RET=\*): " ""
+if { $FWVER == "v2.21.2" } {
+    dialog "Enable xvc access (y/n) (RET=\*): " ""
+}
 dialog "Enter IP address source Mgmt (dec) (RET=\*): " "2"
 dialog "Enter session activity timeout (dec, minutes) (RET=\*): " ""
 dialog "Enter session activity timeout (dec, seconds) (RET=\*): " ""

--- a/expect/dhcp.exp
+++ b/expect/dhcp.exp
@@ -180,7 +180,7 @@ dialog "Enable RMCP access (y/n) (RET=\*): " ""
 dialog "Enable telnet access (y/n) (RET=\*): " ""
 dialog "Enable WEB access (y/n) (RET=\*): " ""
 dialog "Enable ssh access (y/n) (RET=\*): " ""
-if { $FWVER == "v2.21.2" } {
+if { $FWVER == "2.21.2" } {
     dialog "Enable xvc access (y/n) (RET=\*): " ""
 }
 dialog "Enter IP address source Mgmt (dec) (RET=\*): " "2"

--- a/expect/dhcp.exp
+++ b/expect/dhcp.exp
@@ -62,6 +62,10 @@ set DATE [lindex $argv 2]
 # FW version
 #
 set FWVER [lindex $argv 3]
+#
+# Reboot required?
+#
+set REBOOT [lindex $argv 4]
 
 #
 # MCH Configuration Commands File
@@ -189,15 +193,15 @@ dialog "Enter session activity timeout (dec, seconds) (RET=\*): " ""
 dialog "Enter default fan level (dec, percent) (RET=\*): " ""
 dialog "Enable watch dog timer                     (y/n) (RET=\*): " ""
 dialog "Enable alternative cooling scheme          (y/n) (RET=\*): " ""
-dialog "Telnet inactivity timeout (0: disabled or seconds) (RET=\*): " "5"
+dialog "Telnet inactivity timeout (0: disabled or seconds) (RET=\*): " "60"
 dialog "Enable PM relaxed assignment               (y/n) (RET=\*): " ""
 dialog "$mchcfgprompt" "q"
 sleep 5;
 
-
-dialog "$prompt" "reboot"
-
-sleep 20
+if { $REBOOT == "yes" } {
+    dialog "$prompt" "reboot"
+    sleep 20
+}
 
 set tpid [exp_pid -i $spawn_id]
 exec kill -9 $tpid

--- a/expect/dhcp.exp
+++ b/expect/dhcp.exp
@@ -193,7 +193,7 @@ dialog "Enter session activity timeout (dec, seconds) (RET=\*): " ""
 dialog "Enter default fan level (dec, percent) (RET=\*): " ""
 dialog "Enable watch dog timer                     (y/n) (RET=\*): " ""
 dialog "Enable alternative cooling scheme          (y/n) (RET=\*): " ""
-dialog "Telnet inactivity timeout (0: disabled or seconds) (RET=\*): " "60"
+dialog "Telnet inactivity timeout (0: disabled or seconds) (RET=\*): " "300"
 dialog "Enable PM relaxed assignment               (y/n) (RET=\*): " ""
 dialog "$mchcfgprompt" "q"
 sleep 5;

--- a/expect/mchconf.exp
+++ b/expect/mchconf.exp
@@ -206,8 +206,8 @@ dialog "Enable RMCP access (y/n) (RET=\*): " "y"
 dialog "Enable telnet access (y/n) (RET=\*): " "y"
 dialog "Enable WEB access (y/n) (RET=\*): " "y"
 dialog "Enable ssh access (y/n) (RET=\*): " "n"
-if { $FWVER == "v2.21.2"} {
-    dialog "Enable xvc access (y/n) (RET=\*): " ""
+if { $FWVER == "2.21.2"} {
+    dialog "Enable xvc access (y/n) (RET=\*): " "n"
 }
 dialog "Enter IP address source Mgmt (dec) (RET=\*): " "2"
 dialog "Enter session activity timeout (dec, minutes) (RET=\*): " "0"

--- a/expect/mchconf.exp
+++ b/expect/mchconf.exp
@@ -215,7 +215,7 @@ dialog "Enter session activity timeout (dec, seconds) (RET=\*): " "60"
 dialog "Enter default fan level (dec, percent) (RET=\*): " "30"
 dialog "Enable watch dog timer                     (y/n) (RET=\*): " "n"
 dialog "Enable alternative cooling scheme          (y/n) (RET=\*): " "n"
-dialog "Telnet inactivity timeout (0: disabled or seconds) (RET=\*): " "30"
+dialog "Telnet inactivity timeout (0: disabled or seconds) (RET=\*): " "60"
 dialog "Enable PM relaxed assignment               (y/n) (RET=\*): " "n"
 # [ q] quit and save configuration
 dialog "$mchcfgprompt" "q"

--- a/expect/mchconf.exp
+++ b/expect/mchconf.exp
@@ -61,7 +61,10 @@ set port [lindex $argv 1]
 # Date to append to the log file
 #
 set DATE [lindex $argv 2]
-
+#
+# FW version
+#
+set FWVER [lindex $argv 3]
 
 if { [string trimleft $port] == "" } {
     set port "23"
@@ -203,6 +206,9 @@ dialog "Enable RMCP access (y/n) (RET=\*): " "y"
 dialog "Enable telnet access (y/n) (RET=\*): " "y"
 dialog "Enable WEB access (y/n) (RET=\*): " "y"
 dialog "Enable ssh access (y/n) (RET=\*): " "n"
+if { $FWVER == "v2.21.2"} {
+    dialog "Enable xvc access (y/n) (RET=\*): " ""
+}
 dialog "Enter IP address source Mgmt (dec) (RET=\*): " "2"
 dialog "Enter session activity timeout (dec, minutes) (RET=\*): " "0"
 dialog "Enter session activity timeout (dec, seconds) (RET=\*): " "60"

--- a/expect/mchconf.exp
+++ b/expect/mchconf.exp
@@ -215,7 +215,7 @@ dialog "Enter session activity timeout (dec, seconds) (RET=\*): " "60"
 dialog "Enter default fan level (dec, percent) (RET=\*): " "30"
 dialog "Enable watch dog timer                     (y/n) (RET=\*): " "n"
 dialog "Enable alternative cooling scheme          (y/n) (RET=\*): " "n"
-dialog "Telnet inactivity timeout (0: disabled or seconds) (RET=\*): " "60"
+dialog "Telnet inactivity timeout (0: disabled or seconds) (RET=\*): " "300"
 dialog "Enable PM relaxed assignment               (y/n) (RET=\*): " "n"
 # [ q] quit and save configuration
 dialog "$mchcfgprompt" "q"

--- a/expect/mchconf.exp
+++ b/expect/mchconf.exp
@@ -320,6 +320,7 @@ dialog "$mchcfgprompt" "q"
 sleep 2;
 
 #[11] modify DHCP configuration
+dialog "$prompt" "mchcfg"
 dialog "$mchcfgprompt" "11"
 dialog "Enter host name: " "$mch_hostname"
 # [ q] quit and save configuration

--- a/expect/mchconf.exp
+++ b/expect/mchconf.exp
@@ -206,7 +206,7 @@ dialog "Enable RMCP access (y/n) (RET=\*): " "y"
 dialog "Enable telnet access (y/n) (RET=\*): " "y"
 dialog "Enable WEB access (y/n) (RET=\*): " "y"
 dialog "Enable ssh access (y/n) (RET=\*): " "n"
-if { $FWVER == "2.21.2"} {
+if { $FWVER == "2.21"} {
     dialog "Enable xvc access (y/n) (RET=\*): " "n"
 }
 dialog "Enter IP address source Mgmt (dec) (RET=\*): " "2"

--- a/script/jiraHandler.py
+++ b/script/jiraHandler.py
@@ -88,9 +88,8 @@ class JIRAHandler:
             ret = 1
             # Parse response
             if (response.ok == False):
-                if (response.status_code == 500):
-                    print("Provided user credential is not authorised to access the Jira API")
-                    ret = 0
+                print("Provided user credential is not authorised to access the Jira API")
+                ret = 0
 
         return ret
 

--- a/script/mch_config.bash
+++ b/script/mch_config.bash
@@ -427,7 +427,7 @@ function check_fw {
     if [[ ${!VAR} -lt ${DESIRED_VERSION[$i]} ]]; then
       UPDATE=1; break;
     elif [[ ${!VAR} -gt ${DESIRED_VERSION[$i]} ]]; then
-      UPDATE=0; break;
+      UPDATE=1; break;
     fi
   done
 

--- a/script/mch_config.bash
+++ b/script/mch_config.bash
@@ -527,7 +527,7 @@ function cfg_check {
   if [[ $CURRENT_VERSION == "2.21.2" ]]; then
     CFG_GOLDEN_REF=$GENERIC_CFG_2_21
   fi
-  diff --strip-trailing-cr --ignore-blank-lines $CFG_GOLDEN_REF $CFG_TEMPFILE2 > $DIFF_TEMPFILE
+  diff -a --strip-trailing-cr --ignore-blank-lines $CFG_GOLDEN_REF $CFG_TEMPFILE2 > $DIFF_TEMPFILE
   if [[ $? = 0 ]]; then
     $wecho "Configuration file is identical" "$INFO_TAG" "40$port"
     rm $CFG_TEMPFILE
@@ -557,7 +557,7 @@ function clk_check {
     $wecho "Error in MCH clock configuration check." "$ERR_TAG" "40$port"
     exit 1
   fi
-  ip=$(grep -Po 'ip address.*:.\K(\d{1,3}\.?){1,4}' $CFG_TEMPFILE)
+  ip=$(grep -Pao 'ip address.*:.\K(\d{1,3}\.?){1,4}' $CFG_TEMPFILE)
   $wecho "Retrieving the MCH configuration file ($ip)..." "$DBG_TAG" "40$port"
   ping -c 1 $ip &>> /dev/null
   if [[ $? != 0 ]]; then
@@ -567,7 +567,7 @@ function clk_check {
   curl -u root:nat "http://$ip/goform/web_cfg_backup_show_menu" &>> /dev/null
   curl -u root:nat -o $CFG_TEMPFILE "http://$ip/nat_mch_startup_cfg.txt" &>> /dev/null
   local GOLDEN_CFG="GOLDEN_CFG_$FORMFACTOR"
-  diff --strip-trailing-cr --ignore-blank-lines ${!GOLDEN_CFG} $CFG_TEMPFILE > $DIFF_TEMPFILE
+  diff -a --strip-trailing-cr --ignore-blank-lines ${!GOLDEN_CFG} $CFG_TEMPFILE > $DIFF_TEMPFILE
   if [[ $? = 0 ]]; then
     $wecho "Clock configuration file is identical" "$INFO_TAG" "40$port"
     rm $CFG_TEMPFILE

--- a/script/mch_config.bash
+++ b/script/mch_config.bash
@@ -458,6 +458,7 @@ function update_fw {
     sleep $UPDATE_SLEEP
     $wecho "Updated FW version" "$INFO_TAG" "40$port"
     $wecho "Checking FW version after update" "$INFO_TAG" "40$port"
+    get_fw_ver "$1"
     check_fw "$1"
     UPDATED=$?
     if [[ $UPDATED -eq 1 ]]; then

--- a/src/GOLDEN_cfg_2_21.txt
+++ b/src/GOLDEN_cfg_2_21.txt
@@ -1,0 +1,95 @@
+MCH global parameter:
+---------------------
+remote interfaces:
+  RMCP access:                         enabled
+  telnet access:                       enabled
+  WEB access:                          enabled
+  ssh access:                          disabled
+  xvc access:                          disabled
+IP address source Mgmt:                DHCP
+RMCP session activity timeout minutes: 0 min
+RMCP session activity timeout seconds: 60 sec
+default fan level:                     30 percent
+MCH configuration flags:
+  Enable watch dog timer:              no
+  Enable alternative cooling scheme:   no
+  Telnet inact timeout :               30s
+  Set PM Assignment strategy:          strict
+
+Shelf manager parameter:
+------------------------
+ShM configuration flags:
+  allow shelf FRU invalid:             yes
+  temperature management:              enabled
+  emergency shutdown:                  disabled
+  send SEND_MSG confirmation to SMS:   no
+  use external shelf manager:          no
+
+Carrier manager parameter:
+--------------------------
+carrier number default:                0
+quiesced event timeout:                30 sec
+CM configuration flags:
+  allow carrier FRU invalid:           yes
+  overrule carrier FRU:                no
+  shutdown system if MCH goes down:    no
+  enable Clock E-keying:               no
+
+CM debug:
+  IPMI:                                disabled
+  FRU:                                 disabled
+  E-keying:                            disabled
+  sensor:                              disabled
+  event:                               disabled
+  power module:                        disabled
+  cooling unit:                        disabled
+  CM/ShM interface:                    disabled
+  debugging FRU:                       0
+
+SEL parameter:
+--------------
+SEL configuration flags:
+  'keep on read':                      disabled
+  allocate SEL in non-volatile RAM:    yes
+  ignore 'version change' sensor:      yes
+
+Ethernet switch parameter:
+--------------------------
+ configuration source:  no configuration
+ ignore backplane FRU info:            no
+
+CLK module parameter:
+---------------------
+ CLK module configuration source:      load from FLASH
+
+PCIe parameter:
+---------------
+PCIe Virtual Switch configuration
+change via web-interface
+ VS # | Host   | NT-Host | Members
+  0     AMC02_4  none      AMC01_4 AMC01_8 AMC02_4 AMC02_8 AMC03_4 AMC03_8 AMC04_4 AMC04_8 AMC05_4 AMC05_8 AMC06_4 AMC06_8 
+  1     
+  2     
+  3     
+  4     
+  5     
+Upstream slot power up delay:          30 sec
+PCIe hot plug delay for AMCs:          0 sec
+PCIe configuration flags:
+  100 MHz spread spectrum:             disabled
+  hot plug support:                    disabled
+  PCIe early ekey (before payload):    disabled
+  'no ekey' for PCIe:                  disabled
+  Use PCIe on MCH-RTM(disable AMC12):  no
+  PCIe clock configuration:            common
+PCIe module configuration source:      load from FLASH
+
+Time Protocol/SNTP parameter:
+--------------
+Time server IP:                        172.30.0.38
+'Check for Time' delay minutes:        0 min
+'Check for Time' delay hours:          0 h
+local time offset:                     0 h
+Configuration flags:
+  Time client:                         enabled
+  Time client protocol:                SNTP

--- a/src/GOLDEN_cfg_2_21.txt
+++ b/src/GOLDEN_cfg_2_21.txt
@@ -67,7 +67,7 @@ PCIe parameter:
 PCIe Virtual Switch configuration
 change via web-interface
  VS # | Host   | NT-Host | Members
-  0     AMC02_4  none      AMC01_4 AMC01_8 AMC02_4 AMC02_8 AMC03_4 AMC03_8 AMC04_4 AMC04_8 AMC05_4 AMC05_8 AMC06_4 AMC06_8 
+  0     AMC01_4  none      AMC01_4 AMC01_8 AMC02_4 AMC02_8 AMC03_4 AMC03_8 AMC04_4 AMC04_8 AMC05_4 AMC05_8 AMC06_4 AMC06_8 
   1     
   2     
   3     


### PR DESCRIPTION
The tool has been updated to handle firmware versions > 2.20.4.

Initial work has been done to enable compatibility with versions 2.21.2 ... 2.21.6:
- New setting added to the config to enable/disable xvc access.
- But, ultimately we will only support v2.20.4 in the near future, 
  so the tool will downgrade any newer fw version to 2.20.4 

Small fixes:
- More lines need stripped when diff-ing config files via telnet
- Sometimes grep/diff commands were treating input as binary files
- Missing prompt in mchconf.exp

